### PR TITLE
fix: move require to top

### DIFF
--- a/test/ditados-json.test.js
+++ b/test/ditados-json.test.js
@@ -1,10 +1,10 @@
 const { expect, test } = require('@jest/globals')
 const Ajv2020 = require('ajv/dist/2020')
+const ditadosSchemaJson = require('../ditados.schema.json')
+const ditadosJson = require('../ditados.json')
 
 test('validate the ditados json file', () => {
   const ajv = new Ajv2020()
-  const ditadosSchemaJson = require('../ditados.schema.json')
-  const ditadosJson = require('../ditados.json')
   const validate = ajv.compile(ditadosSchemaJson)
 
   expect(validate(ditadosJson)).toBe(true)


### PR DESCRIPTION
Move the `require()`s to the top of the test file, error issued by eslint.

Ref: #54 